### PR TITLE
Avoid complete freezing if FreePBX isn't able to download language

### DIFF
--- a/Soundlang.class.php
+++ b/Soundlang.class.php
@@ -1212,6 +1212,7 @@ class Soundlang extends \FreePBX_Helpers implements \BMO {
 			set_time_limit($this->maxTimeLimit);
 
 			$pest = \FreePBX::Curl()->pest($url);
+			$pest->curl_opts[\CURLOPT_TIMEOUT] = $this->maxTimeLimit;
 			try {
 				$contents = $pest->post($url . $path, $params);
 			} catch(\Exception $e) {


### PR DESCRIPTION
With this fix, there is still a "Proxy Error", but reloading page after a while take to dashboard

NethServer/dev#5364