### PR TITLE
don't create existing directory

### DIFF
--- a/Soundlang.class.php
+++ b/Soundlang.class.php
@@ -1346,7 +1346,9 @@ class Soundlang extends \FreePBX_Helpers implements \BMO {
 
 			// Extract it to the correct location
 			$destdir = "$soundsdir/".$package['language']."/";
-			@mkdir($destdir);
+			if (!file_exists($destdir)) {
+				mkdir($destdir);
+			}
 
 			$file_tar = sprintf("%s/%s", $tmpdir, $filename);
 			try


### PR DESCRIPTION
Prevents warnings during restore from backup:
```none
PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/soundlang/Soundlang.class.php on line 1349

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/soundlang/Soundlang.class.php on line 1349

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/soundlang/Soundlang.class.php on line 1349

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/soundlang/Soundlang.class.php on line 1349
```